### PR TITLE
可能な場合はツイートの本文を省略されないように

### DIFF
--- a/TVTComment/Model/TwitterUtils/ChatTwitterStatusToChat.cs
+++ b/TVTComment/Model/TwitterUtils/ChatTwitterStatusToChat.cs
@@ -7,7 +7,7 @@ namespace TVTComment.Model.TwitterUtils
     {
         public static Chat Convert(Status status)
         {
-            return new Chat(status.CreatedAt.DateTime.ToLocalTime(), status.Text, Chat.PositionType.Normal, Chat.SizeType.Normal, Color.FromArgb(0, 172, 238), status.User.ScreenName, (int)status.Id);
+            return new Chat(status.CreatedAt.DateTime.ToLocalTime(), status.FullText ?? status.Text, Chat.PositionType.Normal, Chat.SizeType.Normal, Color.FromArgb(0, 172, 238), status.User.ScreenName, (int)status.Id);
         }
     }
 }


### PR DESCRIPTION
お世話になっております。こちらもタイトルの通りです。

Twitter API では `text` と `full_text` のフィールドが返されますが, 互換性のため

- 前者は, 140字以内に切り詰められ (...)
- 後者は, 存在する場合は全文が含まれます。

`full_text` が存在すれば `full_text` を, 存在しなければ `text` を返すように変更します。