### PR TITLE
ハッシュタグの正規表現を修正

### DIFF
--- a/TVTComment/Model/ChatModRules/RemoveHashtagChatModRule.cs
+++ b/TVTComment/Model/ChatModRules/RemoveHashtagChatModRule.cs
@@ -7,7 +7,7 @@ namespace TVTComment.Model.ChatModRules
 {
     class RemoveHashtagChatModRule : IChatModRule
     {
-        private static readonly Regex HashtagPattern = new Regex("[#＃](w*[一-龠_ぁ-ん_ァ-ヴーａ-ｚＡ-Ｚa-zA-Z0-9]+|[a-zA-Z0-9_]+|[a-zA-Z0-9_]w*)", RegexOptions.Compiled);
+        private static readonly Regex HashtagPattern = new Regex(@"(?<![\p{L}0-9])([#＃][·・ー_0-9０-９a-zA-Zａ-ｚＡ-Ｚぁ-んァ-ン一-龠]{1,24})(?![\p{L}0-9])", RegexOptions.Compiled);
 
         public string Description => "ハッシュタグを削除";
         public IEnumerable<IChatCollectServiceEntry> TargetChatCollectServiceEntries { get; }


### PR DESCRIPTION
お世話になっております。こちらもタイトルの通りです。

まれに除去されないハッシュタグがあったので正規表現を修正しました。
例えば, `#バック・アロウ` のように中点が含まれる場合などが該当します。
(参考: https://stackoverflow.com/questions/65244827/regular-expression-for-japanese-english-hashtag-like-twitter)

正規表現は https://regex101.com/r/Goaqqs/1 でテストできます。問題なさそうです。