### PR TITLE
2ch スレッドキーワードがない場合に任意のスレッドを選択するように

### DIFF
--- a/TVTComment/Model/NichanUtils/AutoNichanThreadSelector.cs
+++ b/TVTComment/Model/NichanUtils/AutoNichanThreadSelector.cs
@@ -29,9 +29,9 @@ namespace TVTComment.Model.NichanUtils
 
             foreach (var entry in matchingThreads)
             {
-                IEnumerable<string> keywords = entry.ThreadTitleKeywords.Select(
+                var keywords = entry.ThreadTitleKeywords.Select(
                     x => x.ToLower().Normalize(NormalizationForm.FormKD)
-                );
+                ).ToList();
 
                 string boardUri = entry.BoardUri.ToString();
                 var uri = new Uri(boardUri);
@@ -51,8 +51,10 @@ namespace TVTComment.Model.NichanUtils
                 var urls = threadsInBoard.Select(
                     x => { x.Title = x.Title.ToLower().Normalize(NormalizationForm.FormKD); return x; }
                 ).Where(
-                    x => x.ResCount <= 1000 && keywords.All(keyword => x.Title.Contains(keyword))
-                ).OrderByDescending(x => x.ResCount).Take(3).Select(
+                    x => x.ResCount <= 1000
+                ).Where(
+                    x => keywords.Count == 0 || keywords.Any(keyword => x.Title.Contains(keyword))
+                ).OrderByDescending(x => x.ResCount).Take(5).Select(
                     x => $"{boardHost}/test/read.cgi/{boardName}/{x.Name}/l50"
                 );
                 threads.AddRange(urls);

--- a/TVTComment/Model/NichanUtils/AutoPastNichanThreadSelector.cs
+++ b/TVTComment/Model/NichanUtils/AutoPastNichanThreadSelector.cs
@@ -24,9 +24,9 @@ namespace TVTComment.Model.NichanUtils
 
             foreach (var thread in matchingThreads)
             {
-                string[] keywords = thread.ThreadTitleKeywords?.Select(
+                string[] keywords = thread.ThreadTitleKeywords.Select(
                     x => x.ToLower().Normalize(NormalizationForm.FormKD)
-                ).ToArray() ?? Array.Empty<string>();
+                ).ToArray();
                 (string server, string board) = GetServerAndBoardFromBoardUrl(thread.BoardUri.ToString());
 
                 if (!pastThreadListerCache.TryGetValue(board, out var threadLister))
@@ -41,9 +41,9 @@ namespace TVTComment.Model.NichanUtils
                     startTime, startTime + getTimeSpan, cancellationToken
                 ).ConfigureAwait(false);
 
-                var urls = threads.Where(x => keywords.All(
-                    keyword => x.Title.ToLower().Normalize(NormalizationForm.FormKD).Contains(keyword)
-                )).Select(x => x.Uri.ToString());
+                var urls = threads.Where(
+                    x => keywords.Length == 0 || keywords.Any(keyword => x.Title.ToLower().Normalize(NormalizationForm.FormKD).Contains(keyword))
+                ).Select(x => x.Uri.ToString());
                 result.AddRange(urls);
             }
 

--- a/TVTComment/Model/NichanUtils/BoardDatabase.cs
+++ b/TVTComment/Model/NichanUtils/BoardDatabase.cs
@@ -32,19 +32,19 @@ namespace TVTComment.Model.NichanUtils
                         {
                             yield return entry;
                         }
-                        break;
+                        continue;
                     case ThreadMappingRuleTarget.NSId:
                         if (entry.Value == (channel.NetworkId << 16 | channel.ServiceId))
                         {
                             yield return entry;
                         }
-                        break;
+                        continue;
                     case ThreadMappingRuleTarget.NId:
                         if (entry.Value == channel.NetworkId)
                         {
                             yield return entry;
                         }
-                        break;
+                        continue;
                 }
             }
         }
@@ -63,21 +63,24 @@ namespace TVTComment.Model.NichanUtils
         /// </summary>
         public IEnumerable<MatchingThread> GetMatchingThread(ChannelEntry channel)
         {
-            string[] threadTitleKeywords;
-
             var boardAndThread = GetMatchingThreadMappingRuleEntry(channel).ToList();//板名とスレッドタイトルを得る
             foreach (var entry in boardAndThread)
             {
-                if (boardAndThread.Count == 0)
-                    continue;
                 BoardEntry board = GetBoardEntryById(entry.BoardId);//板名から板URLと主要スレッド名を得る
                 if (board == null)
                     continue;
-                threadTitleKeywords = entry.ThreadTitleKeywords ?? board.MainThreadTitleKeywords;
-                if (threadTitleKeywords == null)
-                    continue;
 
-                yield return new MatchingThread(board.Title, board.Uri, threadTitleKeywords);
+                var threadTitleKeywords = new List<string>();
+                if (entry.ThreadTitleKeywords != null)
+                {
+                    threadTitleKeywords.AddRange(entry.ThreadTitleKeywords);
+                }
+                if (board.MainThreadTitleKeywords != null)
+                {
+                    threadTitleKeywords.AddRange(board.MainThreadTitleKeywords);
+                }
+
+                yield return new MatchingThread(board.Title, board.Uri, threadTitleKeywords.ToArray());
             }
         }
     }


### PR DESCRIPTION
`ThreadTitleKeywords` と `MainThreadTitleKeywords` のどちらも設定されていない場合、スキップされていた部分を変更しています。キーワードがない場合にはすべてのスレッドを選択するようにしています。