### PR TITLE
Twitter 実況でストリーミングに失敗した際に REST API ベースの収集に切り替えるように

### DIFF
--- a/TVTComment/Model/ChatCollectService/TwitterLiveChatCollectService.cs
+++ b/TVTComment/Model/ChatCollectService/TwitterLiveChatCollectService.cs
@@ -102,7 +102,7 @@ namespace TVTComment.Model.ChatCollectService
         {
             while (!token.IsCancellationRequested && SearchWord.Value.Equals(searchWord))
             {
-                var response = Twitter.Token.Search.Tweets(q: searchWord, since_id: lastStatusId);
+                var response = Twitter.Token.Search.Tweets(q: searchWord, since_id: lastStatusId, tweet_mode: TweetMode.Extended);
                 var tweets = response.Where(x => !x.Text.StartsWith("RT"))
                     .Where(x => x.Language is null or "und" || x.Language.StartsWith("ja"))
                     .ToList();

--- a/TVTComment/Model/ChatCollectService/TwitterLiveChatCollectService.cs
+++ b/TVTComment/Model/ChatCollectService/TwitterLiveChatCollectService.cs
@@ -115,13 +115,16 @@ namespace TVTComment.Model.ChatCollectService
 
                 if (response.RateLimit.Remaining == 0)
                 {
-                    Task.Delay(15, token);
+                    Thread.Sleep(15);
                 }
                 else
                 {
-                    var duration = DateTime.Now - response.RateLimit.Reset;
-                    var safeRate = duration / response.RateLimit.Remaining;
-                    Task.Delay(safeRate, token);
+                    var duration =  response.RateLimit.Reset - DateTime.Now;
+                    var safeRate = duration / response.RateLimit.Remaining + TimeSpan.FromSeconds(30);
+                    if (safeRate.TotalMilliseconds > 0)
+                    {
+                        Thread.Sleep(safeRate);
+                    }
                 }
             }
         }

--- a/TVTComment/Model/ChatCollectService/TwitterLiveChatCollectService.cs
+++ b/TVTComment/Model/ChatCollectService/TwitterLiveChatCollectService.cs
@@ -78,6 +78,7 @@ namespace TVTComment.Model.ChatCollectService
                 catch (Exception)
                 {
                     isStreaming = false;
+                    lastStatusId = null;
                     SearchTweets(searchWord, token);
                 }
             }, token);
@@ -99,7 +100,7 @@ namespace TVTComment.Model.ChatCollectService
 
         private void SearchTweets(string searchWord, CancellationToken token)
         {
-            while (!token.IsCancellationRequested)
+            while (!token.IsCancellationRequested && SearchWord.Value.Equals(searchWord))
             {
                 var response = Twitter.Token.Search.Tweets(q: searchWord, since_id: lastStatusId);
                 var tweets = response.Where(x => !x.Text.StartsWith("RT"))


### PR DESCRIPTION
Filter Stream はレートリミットが厳しいので、失敗した際にはひとまず REST API で検索を叩くようにしました。

動作確認中です。