### PR TITLE
2ch過去ログの取得処理の高速化

### DIFF
--- a/TVTComment/Model/ChatCollectService/NichanChatCollectService.cs
+++ b/TVTComment/Model/ChatCollectService/NichanChatCollectService.cs
@@ -128,10 +128,10 @@ namespace TVTComment.Model.ChatCollectService
                         IEnumerable<string> threadUris;
                         try
                         {
-                            threadUris = await threadSelector.Get(
+                            threadUris = threadSelector.Get(
                                 currentChannel, new DateTimeOffset(currentTime.Value, TimeSpan.FromHours(9)),
                                 cancellationToken
-                            );
+                            ).ToEnumerable();
                         }
                         catch (HttpRequestException e)
                         {

--- a/TVTComment/Model/Nichan/SubjecttxtParser.cs
+++ b/TVTComment/Model/Nichan/SubjecttxtParser.cs
@@ -23,9 +23,8 @@ namespace Nichan
         /// ただしスレッドのURIはnull。
         /// </summary>
         /// <exception cref="BoardSubjectParserException">解析エラーの場合</exception>
-        public static async Task<IEnumerable<Thread>> ParseFromStream(TextReader reader)
+        public static async IAsyncEnumerable<Thread> ParseFromStream(TextReader reader)
         {
-            var ret = new List<Thread>();
             while (true)
             {
                 string line = await reader.ReadLineAsync();
@@ -60,9 +59,8 @@ namespace Nichan
 
                 title = title[..start].Trim();
 
-                ret.Add(new Thread() { Name = dat, Title = title, ResCount = resCount });
+                yield return new Thread() { Name = dat, Title = title, ResCount = resCount };
             }
-            return ret;
         }
     }
 }

--- a/TVTComment/Model/NichanUtils/FixedNichanThreadSelector.cs
+++ b/TVTComment/Model/NichanUtils/FixedNichanThreadSelector.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace TVTComment.Model.NichanUtils
 {
@@ -15,12 +15,15 @@ namespace TVTComment.Model.NichanUtils
         }
 
 #pragma warning disable CS1998 // この非同期メソッドには 'await' 演算子がないため、同期的に実行されます。'await' 演算子を使用して非ブロッキング API 呼び出しを待機するか、'await Task.Run(...)' を使用してバックグラウンドのスレッドに対して CPU 主体の処理を実行することを検討してください。
-        public async Task<IEnumerable<string>> Get(
+        public async IAsyncEnumerable<string> Get(
 #pragma warning restore CS1998 // この非同期メソッドには 'await' 演算子がないため、同期的に実行されます。'await' 演算子を使用して非ブロッキング API 呼び出しを待機するか、'await Task.Run(...)' を使用してバックグラウンドのスレッドに対して CPU 主体の処理を実行することを検討してください。
-            ChannelInfo channel, DateTimeOffset time, CancellationToken cancellationToken
+            ChannelInfo channel, DateTimeOffset time, [EnumeratorCancellation] CancellationToken cancellationToken
         )
         {
-            return Uris;
+            foreach (var uri in Uris)
+            {
+                yield return uri;
+            }
         }
     }
 }

--- a/TVTComment/Model/NichanUtils/INichanThreadSelector.cs
+++ b/TVTComment/Model/NichanUtils/INichanThreadSelector.cs
@@ -1,13 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace TVTComment.Model.NichanUtils
 {
     interface INichanThreadSelector
     {
-        Task<IEnumerable<string>> Get(
+        IAsyncEnumerable<string> Get(
             ChannelInfo channel, DateTimeOffset time, CancellationToken cancellationToken
         );
     }

--- a/TVTComment/TVTComment.csproj
+++ b/TVTComment/TVTComment.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Prism.Unity" Version="6.3.0-pre1" />
     <PackageReference Include="Prism.Wpf" Version="6.3.0-pre1" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="System.Linq.Async" Version="5.0.0" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />
     <PackageReference Include="System.Text.Json" Version="5.0.0" />
     <PackageReference Include="Unity" Version="4.0.1" />

--- a/TVTComment/ViewModels/ChatCollectServiceCreationOptionControl/NichanChatCollectServiceCreationOptionControlViewModel.cs
+++ b/TVTComment/ViewModels/ChatCollectServiceCreationOptionControl/NichanChatCollectServiceCreationOptionControlViewModel.cs
@@ -88,7 +88,7 @@ namespace TVTComment.ViewModels.ChatCollectServiceCreationOptionControl
             string subject = Encoding.GetEncoding(932).GetString(subjectBytes);
 
             using var textReader = new StringReader(subject);
-            List<Nichan.Thread> threadsInBoard = (await Nichan.SubjecttxtParser.ParseFromStream(textReader)).ToList();
+            List<Nichan.Thread> threadsInBoard = await Nichan.SubjecttxtParser.ParseFromStream(textReader).ToListAsync();
 
             foreach (var thread in threadsInBoard)
                 thread.Uri = new Uri($"{boardHost}/test/read.cgi/{boardName}/{thread.Name}/l50");


### PR DESCRIPTION
`ThreadSelector` のスレッド一覧等を非同期ストリームで返すようにしました。具体的には以下の変更を加えました。

- 見つけたスレッドから順次過去ログの取得を始められるように
  - 従来の仕様だと対象のスレッドをすべて見つけるまで過去ログの取得を始められない状態でした。
  - これにより対象のスレッドが多い場合に高速化が見込めます。

- 過去ログ倉庫から該当のスレッドを探す際にキーワードを使用して絞り込むように
  - 従来の仕様だと「該当の時間のスレッドを見つける」→「スレッドにアクセスして最終書き込み時刻を取得する」→「タイトルで絞り込む」の操作が行われており、大量にスレッドがある板ではタイムアウトすることによりコメント元が終了する状態でした。スレッドにアクセスする前にキーワードで絞り込むことでリクエストを削減しました。
  - 特に [なんJを対象に加えている場合](https://github.com/SlashNephy/TVTComment-txt/blob/master/2chthreads.txt) は効果が大きいです。
 
- 「スレッドにアクセスして最終書き込み時刻を取得する」際に失敗した場合は無視して次のスレッドに進むように