### PR TITLE
fix #10

### DIFF
--- a/NicoJK/NicoJK.h
+++ b/NicoJK/NicoJK.h
@@ -20,7 +20,7 @@ public:
 	// ログファイルフォルダの更新をチェックする間隔
 	static const int READ_LOG_FOLDER_INTERVAL = 3000;*/
 	// チャンネル変更などの後に適当な実況IDのチェックを行うまでの猶予
-	static const int SETUP_CURJK_DELAY = 3000;
+	static const int SETUP_CURJK_DELAY = 5000;
 	// 投稿できる最大コメント文字数(たぶん安易に変更しないほうがいい)
 	//static const int POST_COMMENT_MAX = 76;
 	// 連投制限(短いと規制されるとのウワサ)

--- a/NicoJK/TVTComment/TVTComment.cpp
+++ b/NicoJK/TVTComment/TVTComment.cpp
@@ -367,8 +367,9 @@ namespace TVTComment
 		pi.pszEventText = NULL;
 		pi.pszEventExtText = NULL;
 		this->tvtest->GetCurrentProgramInfo(&pi);//EventIDだけ取れればいい
-		if (pi.EventID != lastEventId)
+		if (pi.EventID != lastEventId && pi.Duration != 3435973836)
 		{
+			//チャンネル変更中などには情報が壊れてるので壊れてるときは送らないように変更
 			//EventIDが変わっていたら
 			TVTest::ChannelInfo ci;
 			ci.Size = sizeof(ci);


### PR DESCRIPTION
チャンネル切替中などはデータが壊れてるので、壊れてるときは送信しないように変更。
チャンネル切替後送信するまでの待機時間を3秒から5秒に変更