### PR TITLE
ソースコードのエンコーディングを UTF-8 BOM に変更

### DIFF
--- a/NicoJK/TVTComment/ChannelInfo.h
+++ b/NicoJK/TVTComment/ChannelInfo.h
@@ -1,4 +1,4 @@
-#pragma once
+ï»¿#pragma once
 #include <string>
 
 namespace TVTComment
@@ -30,6 +30,6 @@ namespace TVTComment
 
 		unsigned short ServiceID;
 
-		bool Hidden;//TVTest‚Ìİ’è‚Å”ñ•\¦‚É‚È‚Á‚Ä‚¢‚é
+		bool Hidden;//TVTestã®è¨­å®šã§éè¡¨ç¤ºã«ãªã£ã¦ã„ã‚‹
 	};
 }

--- a/NicoJK/TVTComment/IPC/IPCMessage/ChannelSelectIPCMessage.cpp
+++ b/NicoJK/TVTComment/IPC/IPCMessage/ChannelSelectIPCMessage.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+ï»¿#include "stdafx.h"
 #include "ChannelSelectIPCMessage.h"
 #include <stdexcept>
 #include "../IPCMessageDecodeError.h"
@@ -18,7 +18,7 @@ namespace TVTComment
 	void ChannelSelectIPCMessage::Decode(const std::vector<std::string> &contents)
 	{
 		if (contents.size() != 3)
-			throw IPCMessageDecodeError("ChannelSelect‚Ìcontents‚Ì”‚ª3ˆÈŠO‚Å‚·");
+			throw IPCMessageDecodeError("ChannelSelectã®contentsã®æ•°ãŒ3ä»¥å¤–ã§ã™");
 
 		try
 		{
@@ -28,7 +28,7 @@ namespace TVTComment
 		}
 		catch (std::invalid_argument)
 		{
-			throw IPCMessageDecodeError("ChannelSelect‚ÌƒtƒH[ƒ}ƒbƒg‚ª•s³‚Å‚·");
+			throw IPCMessageDecodeError("ChannelSelectã®ãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆãŒä¸æ­£ã§ã™");
 		}
 	}
 }

--- a/NicoJK/TVTComment/IPC/IPCMessage/ChatIPCMessage.cpp
+++ b/NicoJK/TVTComment/IPC/IPCMessage/ChatIPCMessage.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+ï»¿#include "stdafx.h"
 #include "ChatIPCMessage.h"
 #include "../IPCMessageDecodeError.h"
 #include <cstdlib>
@@ -46,7 +46,7 @@ namespace TVTComment
 	void ChatIPCMessage::Decode(const std::vector<std::string> &contents)
 	{
 		if (contents.size() != 4)
-			throw IPCMessageDecodeError("Chat‚Ìcontents‚Ì”‚ª4ˆÈŠO‚Å‚·");
+			throw IPCMessageDecodeError("Chatã®contentsã®æ•°ãŒ4ä»¥å¤–ã§ã™");
 
 		this->Chat.text = contents[0];
 
@@ -57,7 +57,7 @@ namespace TVTComment
 		else if (contents[1] == "Top")
 			this->Chat.position = Chat::Position::Top;
 		else
-			throw IPCMessageDecodeError("Chat‚ÌPosition‚Ì’l‚ª•s³‚Å‚·: "+contents[1]);
+			throw IPCMessageDecodeError("Chatã®Positionã®å€¤ãŒä¸æ­£ã§ã™: "+contents[1]);
 
 		if (contents[2] == "Default")
 			this->Chat.size = Chat::Size::Default;
@@ -66,7 +66,7 @@ namespace TVTComment
 		else if (contents[2] == "Large")
 			this->Chat.size = Chat::Size::Large;
 		else
-			throw IPCMessageDecodeError("Chat‚ÌSize‚Ì’l‚ª•s³‚Å‚·: " + contents[1]);
+			throw IPCMessageDecodeError("Chatã®Sizeã®å€¤ãŒä¸æ­£ã§ã™: " + contents[1]);
 
 		std::string colorstr = contents[3]+",";
 		int count=0;
@@ -86,8 +86,8 @@ namespace TVTComment
 				break;
 			}
 		}
-		//ƒtƒH[ƒ}ƒbƒg‚ªR,G,B‚Å‚àR,G,B,‚Å‚à‚È‚¢‚È‚ç
+		//ãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆãŒR,G,Bã§ã‚‚R,G,B,ã§ã‚‚ãªã„ãªã‚‰
 		if (count != 3 && count != 4)
-			throw IPCMessageDecodeError("Chat‚ÌColor‚ÌƒtƒH[ƒ}ƒbƒg‚ª•s³‚Å‚·: " + contents[3]);
+			throw IPCMessageDecodeError("Chatã®Colorã®ãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆãŒä¸æ­£ã§ã™: " + contents[3]);
 	}
 }

--- a/NicoJK/TVTComment/IPC/IPCMessage/CommandIPCMessage.cpp
+++ b/NicoJK/TVTComment/IPC/IPCMessage/CommandIPCMessage.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+ï»¿#include "stdafx.h"
 #include "CommandIPCMessage.h"
 #include "../IPCMessageDecodeError.h"
 
@@ -17,7 +17,7 @@ namespace TVTComment
 	void CommandIPCMessage::Decode(const std::vector<std::string> &contents)
 	{
 		if (contents.size() != 1)
-			throw IPCMessageDecodeError("CommandIPCMessage‚Ìcontents‚Ì”‚ª1ˆÈŠO‚Å‚·");
+			throw IPCMessageDecodeError("CommandIPCMessageã®contentsã®æ•°ãŒ1ä»¥å¤–ã§ã™");
 		
 		this->CommandId = contents[0];
 	}

--- a/NicoJK/TVTComment/IPC/IPCMessage/SetChatOpacityIPCMessage.cpp
+++ b/NicoJK/TVTComment/IPC/IPCMessage/SetChatOpacityIPCMessage.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+ï»¿#include "stdafx.h"
 #include <stdexcept>
 #include "SetChatOpacityIPCMessage.h"
 #include "../IPCMessageDecodeError.h"
@@ -16,7 +16,7 @@ namespace TVTComment
 	void SetChatOpacityIPCMessage::Decode(const std::vector<std::string> &contents)
 	{
 		if (contents.size() != 1)
-			throw IPCMessageDecodeError("SetChatOpacity‚Ìcontents‚Ì”‚ª1ˆÈŠO‚Å‚·");
+			throw IPCMessageDecodeError("SetChatOpacityã®contentsã®æ•°ãŒ1ä»¥å¤–ã§ã™");
 		int val;
 		try
 		{
@@ -24,11 +24,11 @@ namespace TVTComment
 		}
 		catch (std::invalid_argument)
 		{
-			throw IPCMessageDecodeError("SetChatOpacity‚ÌƒtƒH[ƒ}ƒbƒg‚ª•s³‚Å‚·");
+			throw IPCMessageDecodeError("SetChatOpacityã®ãƒ•ã‚©ãƒ¼ãƒãƒƒãƒˆãŒä¸æ­£ã§ã™");
 		}
 		if (0 <= val && val <= 255)
 			this->Opacity = (unsigned char)val;
 		else
-			throw IPCMessageDecodeError("SetChatOpacity‚Ì“§‰ß“x‚ª0`255‚Ì”ÍˆÍŠO‚Å‚·");
+			throw IPCMessageDecodeError("SetChatOpacityã®é€éåº¦ãŒ0ï½255ã®ç¯„å›²å¤–ã§ã™");
 	}
 }

--- a/NicoJK/TVTComment/IPC/IPCMessageFactory.cpp
+++ b/NicoJK/TVTComment/IPC/IPCMessageFactory.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+ï»¿#include "stdafx.h"
 #include "IPCMessageFactory.h"
 #include "IPCMessageDecodeError.h"
 #include "IPCMessage/ChatIPCMessage.h"
@@ -32,7 +32,7 @@ namespace TVTComment
 		else if (rawmsg.MessageName == "Command")
 			msg = new CommandIPCMessage();
 		else
-			throw IPCMessageDecodeError("•s–¾‚ÈMessageName‚Å‚·: " + rawmsg.ToString());
+			throw IPCMessageDecodeError("ä¸æ˜ãªMessageNameã§ã™: " + rawmsg.ToString());
 
 		std::unique_ptr<IIPCMessage> ret(msg);
 		ret->Decode(rawmsg.Contents);

--- a/NicoJK/TVTComment/IPC/IPCProtocolStream.h
+++ b/NicoJK/TVTComment/IPC/IPCProtocolStream.h
@@ -1,9 +1,9 @@
-#pragma once
+﻿#pragma once
 #include "RawIPCMessage.h"
 #include <istream>
 namespace TVTComment
 {
-	//0x1E(Record Separator),0x1F(Unit Separator)�����͓`���f�[�^�Ɋ܂߂Ă͂Ȃ�Ȃ�
+	//0x1E(Record Separator),0x1F(Unit Separator)文字は伝送データに含めてはならない
 	class IPCProtocolStream
 	{
 	private:

--- a/NicoJK/TVTComment/IPC/IPCTunnel.h
+++ b/NicoJK/TVTComment/IPC/IPCTunnel.h
@@ -1,4 +1,4 @@
-#pragma once
+ï»¿#pragma once
 #include "IPCProtocolStream.h"
 #include "IPCMessage/IIPCMessage.h"
 #include "../win32filestream.h"
@@ -19,9 +19,9 @@ namespace TVTComment
 		virtual const char *what() const override { return what_arg.c_str(); }
 	};
 
-	//ƒvƒƒZƒXŠÔ’ÊMƒgƒ“ƒlƒ‹
-	//Connect‚ªŠ®—¹‚·‚é‘O‚ÉSend‚âReceive‚ğŒÄ‚Ô‚Æ–¢’è‹`“®ì
-	//Send‚ÆReceive©‘Ì‚ÌÄ“ü‚Í‚Å‚«‚È‚¢‚ª•ÊƒXƒŒƒbƒh‚©‚çSend‚ÆReceive‚ğ“¯‚ÉŒÄ‚ñ‚ÅOK
+	//ãƒ—ãƒ­ã‚»ã‚¹é–“é€šä¿¡ãƒˆãƒ³ãƒãƒ«
+	//ConnectãŒå®Œäº†ã™ã‚‹å‰ã«Sendã‚„Receiveã‚’å‘¼ã¶ã¨æœªå®šç¾©å‹•ä½œ
+	//Sendã¨Receiveè‡ªä½“ã®å†å…¥ã¯ã§ããªã„ãŒåˆ¥ã‚¹ãƒ¬ãƒƒãƒ‰ã‹ã‚‰Sendã¨Receiveã‚’åŒæ™‚ã«å‘¼ã‚“ã§OK
 	class IPCTunnel
 	{
 	private:
@@ -36,7 +36,7 @@ namespace TVTComment
 		void Connect();
 		void Send(const IIPCMessage &msg);
 		std::unique_ptr<IIPCMessage> Receive();
-		void Cancel() noexcept;//ˆ—’†‚ÌConnect,Send,Receive‚ğƒLƒƒƒ“ƒZƒ‹‚µAstd::system_error‚Å‹A‚ç‚¹‚é
-		~IPCTunnel() noexcept;//Cancel‚ğŒÄ‚ñ‚¾Œã
+		void Cancel() noexcept;//å‡¦ç†ä¸­ã®Connect,Send,Receiveã‚’ã‚­ãƒ£ãƒ³ã‚»ãƒ«ã—ã€std::system_errorã§å¸°ã‚‰ã›ã‚‹
+		~IPCTunnel() noexcept;//Cancelã‚’å‘¼ã‚“ã å¾Œ
 	};
 }

--- a/NicoJK/TVTComment/TVTComment.cpp
+++ b/NicoJK/TVTComment/TVTComment.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+ï»¿#include "stdafx.h"
 #include "TVTComment.h"
 #include "IPC/IPCMessage/ChannelListIPCMessage.h"
 #include "IPC/IPCMessage/ChatIPCMessage.h"
@@ -19,8 +19,8 @@ namespace TVTComment
 {
 	std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> TVTComment::utf8_utf16_conv;
 
-	//Task“à‚©‚çŒÄ‚Ño‚·‘O’ñ‚Åì‚ç‚ê‚Ä‚¢‚é
-	//Ú‘±Š®—¹‚Ü‚ÅƒuƒƒbƒN‚·‚é‚ªAƒLƒƒƒ“ƒZƒ‹‚³‚ê‚½ê‡‚Íconcurrency::task_canceled—áŠO‚ğ‘—o‚·‚é
+	//Taskå†…ã‹ã‚‰å‘¼ã³å‡ºã™å‰æã§ä½œã‚‰ã‚Œã¦ã„ã‚‹
+	//æ¥ç¶šå®Œäº†ã¾ã§ãƒ–ãƒ­ãƒƒã‚¯ã™ã‚‹ãŒã€ã‚­ãƒ£ãƒ³ã‚»ãƒ«ã•ã‚ŒãŸå ´åˆã¯concurrency::task_canceledä¾‹å¤–ã‚’é€å‡ºã™ã‚‹
 	void TVTComment::doConnect()
 	{
 		for (int i = 0;; i++)
@@ -30,7 +30,7 @@ namespace TVTComment
 			concurrency::interruption_point();
 			try
 			{
-				//ƒvƒƒZƒXŠÔ’ÊM‚Ég‚¤ƒpƒCƒv–¼‚ğUUID‚©‚çì‚é
+				//ãƒ—ãƒ­ã‚»ã‚¹é–“é€šä¿¡ã«ä½¿ã†ãƒ‘ã‚¤ãƒ—åã‚’UUIDã‹ã‚‰ä½œã‚‹
 				UUID uuid;
 				RPC_WSTR uuidStr;
 				std::wstring receivePipeName=LR"(\\.\pipe\TVTComment_Up_)";
@@ -58,11 +58,11 @@ namespace TVTComment
 
 				concurrency::interruption_point();
 
-				//ˆê’è‰ñ”‚µ‚Ä‚·‚×‚Ä¸”s‚µ‚½‚çƒGƒ‰[
+				//ä¸€å®šå›æ•°è©¦ã—ã¦ã™ã¹ã¦å¤±æ•—ã—ãŸã‚‰ã‚¨ãƒ©ãƒ¼
 				if (i > 5)
 					throw;
 
-				//‚à‚¤ˆê‰ñ‚µ‚Ä‚İ‚é
+				//ã‚‚ã†ä¸€å›è©¦ã—ã¦ã¿ã‚‹
 				std::this_thread::sleep_for(std::chrono::seconds(1));
 				continue;
 			}
@@ -73,7 +73,7 @@ namespace TVTComment
 
 	void TVTComment::receiveLoop()
 	{
-		//ƒƒbƒZ[ƒWóMƒ‹[ƒv
+		//ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸å—ä¿¡ãƒ«ãƒ¼ãƒ—
 		try
 		{
 			while (true)
@@ -94,7 +94,7 @@ namespace TVTComment
 				catch (std::system_error &)
 				{
 					if (this->isClosing)
-						throw;//‘Šè‚ªÚ‘±‚ğØ‚Á‚½
+						throw;//ç›¸æ‰‹ãŒæ¥ç¶šã‚’åˆ‡ã£ãŸ
 
 					PostMessage(this->dialog, WM_USERINTERACTIONREQUEST, (WPARAM)UserInteractionRequestType::ReceiveError, 0);
 					errorCount++;
@@ -105,7 +105,7 @@ namespace TVTComment
 		}
 		catch (std::exception &e)
 		{
-			//‰½‚ç‚©‚ÌƒGƒ‰[‚ª‹N‚±‚Á‚½A‘Šè‚ªÚ‘±‚ğØ‚Á‚½
+			//ä½•ã‚‰ã‹ã®ã‚¨ãƒ©ãƒ¼ãŒèµ·ã“ã£ãŸæ™‚ã€ç›¸æ‰‹ãŒæ¥ç¶šã‚’åˆ‡ã£ãŸæ™‚
 			if (!this->isClosing)
 			{
 				static std::wstring_convert<std::codecvt<wchar_t, char, mbstate_t >> char_wide_conv;
@@ -123,7 +123,7 @@ namespace TVTComment
 	void TVTComment::processReceivedMessage(const IIPCMessage &msg)
 	{
 #pragma warning(push)
-#pragma warning(disable:4456)//•Ï”message‚ÌéŒ¾‚ª”í‚Á‚Ä‚¢‚é‚Ì‚É‘Î‚·‚éŒx—}~
+#pragma warning(disable:4456)//å¤‰æ•°messageã®å®£è¨€ãŒè¢«ã£ã¦ã„ã‚‹ã®ã«å¯¾ã™ã‚‹è­¦å‘ŠæŠ‘æ­¢
 		if (auto message = dynamic_cast<const ChatIPCMessage *>(&msg))
 		{
 			const Chat &chat = message->Chat;
@@ -152,7 +152,7 @@ namespace TVTComment
 
 	bool TVTComment::sendMessage(const IIPCMessage &msg)
 	{
-		//closingó‘Ô‚È‚çCloseIPCMessageˆÈŠO‚Í‘—‚ç‚È‚¢
+		//closingçŠ¶æ…‹ãªã‚‰CloseIPCMessageä»¥å¤–ã¯é€ã‚‰ãªã„
 		if (this->isClosing && dynamic_cast<const CloseIPCMessage *>(&msg) == nullptr)
 			return false;
 
@@ -200,12 +200,12 @@ namespace TVTComment
 				}
 				catch (concurrency::task_canceled)
 				{
-					//Ú‘±ˆ—’†‚ÉƒLƒƒƒ“ƒZƒ‹‚³‚ê‚½
+					//æ¥ç¶šå‡¦ç†ä¸­ã«ã‚­ãƒ£ãƒ³ã‚»ãƒ«ã•ã‚ŒãŸ
 					throw;
 				}
 				catch (std::system_error &e)
 				{
-					//Ú‘±‚ª¸”s‚µ‚½
+					//æ¥ç¶šãŒå¤±æ•—ã—ãŸ
 					std::wstring_convert<std::codecvt<wchar_t, char, mbstate_t >> char_wide_conv;
 
 					std::wstring what = char_wide_conv.from_bytes(e.what());
@@ -218,14 +218,14 @@ namespace TVTComment
 					throw;
 				}
 
-				//³í‚ÉÚ‘±‚ªŠ®—¹‚µ‚½
+				//æ­£å¸¸ã«æ¥ç¶šãŒå®Œäº†ã—ãŸ
 				PostMessage(this->dialog, WM_USERINTERACTIONREQUEST, (WPARAM)UserInteractionRequestType::ConnectSucceed, 0);
 				this->isConnected = true;
 
 				PostMessage(this->dialog, WM_ONCHANNELLISTCHANGE, 0, 0);
 				PostMessage(this->dialog, WM_ONCHANNELSELECTIONCHANGE, 0, 0);
 				
-				//óMƒ‹[ƒvŠJn
+				//å—ä¿¡ãƒ«ãƒ¼ãƒ—é–‹å§‹
 				this->receiveLoop();
 			}, cancel.get_token());
 			break;
@@ -241,36 +241,36 @@ namespace TVTComment
 			case UserInteractionRequestType::ConnectFail:
 			{
 				wchar_t *t = (wchar_t *)lParam;
-				std::wstring text = L"TVTCommentİ’èƒEƒBƒ“ƒhƒE‚Æ‚ÌÚ‘±‚É¸”s‚µ‚Ü‚µ‚½Bƒvƒ‰ƒOƒCƒ“‚ğ–³Œø‰»‚µ‚Ü‚·B";
+				std::wstring text = L"TVTCommentè¨­å®šã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã¨ã®æ¥ç¶šã«å¤±æ•—ã—ã¾ã—ãŸã€‚ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’ç„¡åŠ¹åŒ–ã—ã¾ã™ã€‚";
 				/*if (t != nullptr)
 				{
 					text += L"\n\n";
 					text += t;
 					delete[] t;
 				}*/
-				MessageBoxW(this->tvtest->GetAppWindow(), text.c_str(), L"TVTComment•\¦‘¤ƒGƒ‰[", 0);
+				MessageBoxW(this->tvtest->GetAppWindow(), text.c_str(), L"TVTCommentè¡¨ç¤ºå´ã‚¨ãƒ©ãƒ¼", 0);
 				break;
 			}
 			case UserInteractionRequestType::InvalidMessage:
-				this->commentWindow->AddChat(TEXT("[TVTCommentŠÔ’ÊM‚Å–³Œø‚ÈƒƒbƒZ[ƒW‚ğóM‚µ‚Ü‚µ‚½]"), RGB(255, 0, 0), CCommentWindow::CHAT_POS_UE, CCommentWindow::CHAT_SIZE_SMALL);
+				this->commentWindow->AddChat(TEXT("[TVTCommenté–“é€šä¿¡ã§ç„¡åŠ¹ãªãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’å—ä¿¡ã—ã¾ã—ãŸ]"), RGB(255, 0, 0), CCommentWindow::CHAT_POS_UE, CCommentWindow::CHAT_SIZE_SMALL);
 				break;
 			case UserInteractionRequestType::ReceiveError:
-				this->commentWindow->AddChat(TEXT("[TVTCommentŠÔ’ÊM‚ÅƒƒbƒZ[ƒW‚ÌóM‚É¸”s‚µ‚Ü‚µ‚½]"), RGB(255, 0, 0), CCommentWindow::CHAT_POS_UE, CCommentWindow::CHAT_SIZE_SMALL);
+				this->commentWindow->AddChat(TEXT("[TVTCommenté–“é€šä¿¡ã§ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã®å—ä¿¡ã«å¤±æ•—ã—ã¾ã—ãŸ]"), RGB(255, 0, 0), CCommentWindow::CHAT_POS_UE, CCommentWindow::CHAT_SIZE_SMALL);
 				break;
 			case UserInteractionRequestType::SendError:
-				this->commentWindow->AddChat(TEXT("[TVTCommentŠÔ’ÊM‚ÅƒƒbƒZ[ƒW‚Ì‘—M‚É¸”s‚µ‚Ü‚µ‚½]"), RGB(255, 0, 0), CCommentWindow::CHAT_POS_UE, CCommentWindow::CHAT_SIZE_SMALL);
+				this->commentWindow->AddChat(TEXT("[TVTCommenté–“é€šä¿¡ã§ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã®é€ä¿¡ã«å¤±æ•—ã—ã¾ã—ãŸ]"), RGB(255, 0, 0), CCommentWindow::CHAT_POS_UE, CCommentWindow::CHAT_SIZE_SMALL);
 				break;
 			case UserInteractionRequestType::FetalErrorInTask:
 			{
 				wchar_t *t = (wchar_t *)lParam;
-				std::wstring text = L"TVTCommentİ’èƒEƒBƒ“ƒhƒE‚©‚ç‚ÌóMˆ—‚Å’v–½“I‚È–â‘è‚ª”­¶‚µ‚Ü‚µ‚½B\nƒvƒ‰ƒOƒCƒ“‚ğ–³Œø‰»‚µ‚Ü‚·B";
+				std::wstring text = L"TVTCommentè¨­å®šã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã‹ã‚‰ã®å—ä¿¡å‡¦ç†ã§è‡´å‘½çš„ãªå•é¡ŒãŒç™ºç”Ÿã—ã¾ã—ãŸã€‚\nãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’ç„¡åŠ¹åŒ–ã—ã¾ã™ã€‚";
 				/*if (t != nullptr)
 				{
 					text += L"\n\n";
 					text += t;
 					delete[] t;
 				}*/
-				MessageBoxW(this->tvtest->GetAppWindow(), text.c_str(), L"TVTComment•\¦‘¤ƒGƒ‰[", 0);
+				MessageBoxW(this->tvtest->GetAppWindow(), text.c_str(), L"TVTCommentè¡¨ç¤ºå´ã‚¨ãƒ©ãƒ¼", 0);
 				break;
 			}
 			}
@@ -354,22 +354,22 @@ namespace TVTComment
 		sendCurrentChannelIPCMessage(ci, pi);
 	}
 
-	//TOT‚ÌXVŠÔŠu‚æ‚è’Z‚¢ŠÔŠu‚Å’èŠú“I‚ÉŒÄ‚Ô
+	//TOTæ™‚åˆ»ã®æ›´æ–°é–“éš”ã‚ˆã‚ŠçŸ­ã„é–“éš”ã§å®šæœŸçš„ã«å‘¼ã¶
 	void TVTComment::OnForward(std::time_t tot)
 	{
 		if (!this->isConnected)
 			return;
 
-		//Event(”Ô‘g)‚ª•Ï‚í‚Á‚Ä‚½‚ç’Ê’m
+		//Event(ç•ªçµ„)ãŒå¤‰ã‚ã£ã¦ãŸã‚‰é€šçŸ¥
 		TVTest::ProgramInfo pi;
 		pi.Size = sizeof(pi);
 		pi.pszEventName = NULL;
 		pi.pszEventText = NULL;
 		pi.pszEventExtText = NULL;
-		this->tvtest->GetCurrentProgramInfo(&pi);//EventID‚¾‚¯æ‚ê‚ê‚Î‚¢‚¢
+		this->tvtest->GetCurrentProgramInfo(&pi);//EventIDã ã‘å–ã‚Œã‚Œã°ã„ã„
 		if (pi.EventID != lastEventId)
 		{
-			//EventID‚ª•Ï‚í‚Á‚Ä‚¢‚½‚ç
+			//EventIDãŒå¤‰ã‚ã£ã¦ã„ãŸã‚‰
 			TVTest::ChannelInfo ci;
 			ci.Size = sizeof(ci);
 			this->tvtest->GetCurrentChannelInfo(&ci);
@@ -389,7 +389,7 @@ namespace TVTComment
 			sendCurrentChannelIPCMessage(ci, pi);
 		}
 		
-		//Tot‚ª•Ï‚í‚Á‚Ä‚½‚ç’Ê’m
+		//TotãŒå¤‰ã‚ã£ã¦ãŸã‚‰é€šçŸ¥
 		if (tot != lastTOT)
 		{
 			this->lastTOT = tot;
@@ -413,7 +413,7 @@ namespace TVTComment
 	}
 
 #pragma warning(push)
-#pragma warning(disable: 4701)//–¢‰Šú‰»‚Ìƒ[ƒJƒ‹•Ï”si‚ğg‚Á‚Ä‚¢‚é‚Æ‚·‚éŒx‚Ì—}~
+#pragma warning(disable: 4701)//æœªåˆæœŸåŒ–ã®ãƒ­ãƒ¼ã‚«ãƒ«å¤‰æ•°siã‚’ä½¿ã£ã¦ã„ã‚‹ã¨ã™ã‚‹è­¦å‘Šã®æŠ‘æ­¢
 	void TVTComment::sendCurrentChannelIPCMessage(const TVTest::ChannelInfo &ci, const TVTest::ProgramInfo &pi)
 	{
 		if (!this->isConnected)
@@ -421,7 +421,7 @@ namespace TVTComment
 		TVTest::ServiceInfo si;
 		si.Size = sizeof(si);
 		int serviceIdx=this->tvtest->GetService();
-		if (serviceIdx < 0) //ƒ`ƒƒƒ“ƒlƒ‹•ÏX’†‚È‚Ç‚É‚Íî•ñ‚ª‰ó‚ê‚Ä‚é‚Ì‚Å‰ó‚ê‚Ä‚é‚Æ‚«‚Í”²‚¯‚é‚æ‚¤‚É•ÏX
+		if (serviceIdx < 0) //ãƒãƒ£ãƒ³ãƒãƒ«å¤‰æ›´ä¸­ãªã©ã«ã¯æƒ…å ±ãŒå£Šã‚Œã¦ã‚‹ã®ã§å£Šã‚Œã¦ã‚‹ã¨ãã¯æŠœã‘ã‚‹ã‚ˆã†ã«å¤‰æ›´
 			return;
 		this->tvtest->GetServiceInfo(serviceIdx, &si);
 
@@ -435,9 +435,9 @@ namespace TVTComment
 		msg.ServiceId = serviceIdx == -1 ? ci.ServiceID : si.ServiceID;
 		msg.EventId = pi.EventID;
 
-		if(ci.NetworkID!=0)//ƒ`ƒƒƒ“ƒlƒ‹ƒXƒLƒƒƒ“‚µ‚Ä‚È‚¢iFileŒnBonDriver‚È‚Çj‚ÆNID==0‚ÅNetworkName‚à³‚µ‚¢’l‚ğ•Ô‚³‚È‚¢
+		if(ci.NetworkID!=0)//ãƒãƒ£ãƒ³ãƒãƒ«ã‚¹ã‚­ãƒ£ãƒ³ã—ã¦ãªã„ï¼ˆFileç³»BonDriverãªã©ï¼‰ã¨NID==0ã§NetworkNameã‚‚æ­£ã—ã„å€¤ã‚’è¿”ã•ãªã„
 			msg.NetworkName.assign(utf8_utf16_conv.to_bytes(ci.szNetworkName));
-		if(ci.TransportStreamID!=0)//ƒ`ƒƒƒ“ƒlƒ‹ƒXƒLƒƒƒ“‚µ‚Ä‚È‚¢iFileŒnBonDriver‚È‚Çj‚ÆTSID==0‚ÅTransportStreamName‚à³‚µ‚¢’l‚ğ•Ô‚³‚È‚¢
+		if(ci.TransportStreamID!=0)//ãƒãƒ£ãƒ³ãƒãƒ«ã‚¹ã‚­ãƒ£ãƒ³ã—ã¦ãªã„ï¼ˆFileç³»BonDriverãªã©ï¼‰ã¨TSID==0ã§TransportStreamNameã‚‚æ­£ã—ã„å€¤ã‚’è¿”ã•ãªã„
 			msg.TransportstreamName.assign(utf8_utf16_conv.to_bytes(ci.szTransportStreamName));
 		if(serviceIdx!=-1)
 			msg.ServiceName.assign(utf8_utf16_conv.to_bytes(si.szServiceName));
@@ -450,7 +450,7 @@ namespace TVTComment
 		msg.StartTime = SystemTimeToUnixTime(pi.StartTime);
 		msg.Duration = pi.Duration;
 
-		//ÅŒã‚É‘—‚Á‚½EventID‚ğ‹L‰¯
+		//æœ€å¾Œã«é€ã£ãŸEventIDã‚’è¨˜æ†¶
 		this->lastEventId = pi.EventID;
 
 		this->sendMessage(msg);

--- a/NicoJK/TVTComment/TVTComment.h
+++ b/NicoJK/TVTComment/TVTComment.h
@@ -1,4 +1,4 @@
-#pragma once
+ï»¿#pragma once
 #include "../TVTestPlugin.h"
 #include "../CommentWindow.h"
 #include "../Util.h"
@@ -23,9 +23,9 @@ namespace TVTComment
 		ShowWindow,
 	};
 
-	//TVTComment‚ÌÅãˆÊƒNƒ‰ƒX
-	//‚±‚ÌƒNƒ‰ƒX‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚Ì¶‘¶ŠúŠÔ‚Í¨‚¢ƒEƒBƒ“ƒhƒE‚Ì‚æ‚è’·‚¢•K—v‚ª‚ ‚é
-	//ƒGƒ‰[‚Éƒvƒ‰ƒOƒCƒ“‚ğ–³Œø‰»‚·‚é‚±‚Æ‚ª‚ ‚é
+	//TVTCommentã®æœ€ä¸Šä½ã‚¯ãƒ©ã‚¹
+	//ã“ã®ã‚¯ãƒ©ã‚¹ã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã®ç”Ÿå­˜æœŸé–“ã¯å‹¢ã„ã‚¦ã‚£ãƒ³ãƒ‰ã‚¦ã®ã‚ˆã‚Šé•·ã„å¿…è¦ãŒã‚ã‚‹
+	//ã‚¨ãƒ©ãƒ¼æ™‚ã«ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’ç„¡åŠ¹åŒ–ã™ã‚‹ã“ã¨ãŒã‚ã‚‹
 	class TVTComment
 	{
 	private:
@@ -36,20 +36,20 @@ namespace TVTComment
 		std::time_t lastTOT;
 		uint16_t lastEventId;
 
-		int errorCount;//óMƒGƒ‰[‚ª‹N‚«‚½‰ñ”
-		static constexpr int FETALERROR_COUNT = 10;//errorCount‚ª‚±‚Ì’lˆÈã‚É‚È‚é‚Æƒvƒ‰ƒOƒCƒ“‚ğ–³Œø‰»‚·‚é
+		int errorCount;//å—ä¿¡ã‚¨ãƒ©ãƒ¼ãŒèµ·ããŸå›æ•°
+		static constexpr int FETALERROR_COUNT = 10;//errorCountãŒã“ã®å€¤ä»¥ä¸Šã«ãªã‚‹ã¨ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’ç„¡åŠ¹åŒ–ã™ã‚‹
 
-		std::atomic<bool> isClosing;//ClosingIPCMessage‚ğó‚¯æ‚èƒvƒ‰ƒOƒCƒ“‚ğ•Â‚¶‚æ‚¤‚Æ‚µ‚Ä‚¢‚é
+		std::atomic<bool> isClosing;//ClosingIPCMessageã‚’å—ã‘å–ã‚Šãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’é–‰ã˜ã‚ˆã†ã¨ã—ã¦ã„ã‚‹
 
 		std::atomic<bool> isConnected;
 		std::unique_ptr<IPCTunnel> ipcTunnel;
 
 		std::vector<ChannelInfo> channelList;
 
-		concurrency::cancellation_token_source cancel;//‚±‚ÌTVTCommentƒNƒ‰ƒX‚ÌƒCƒ“ƒXƒ^ƒ“ƒX‚ğdelete‚·‚é‚Æ‚«‚Ég‚¤
+		concurrency::cancellation_token_source cancel;//ã“ã®TVTCommentã‚¯ãƒ©ã‚¹ã®ã‚¤ãƒ³ã‚¹ã‚¿ãƒ³ã‚¹ã‚’deleteã™ã‚‹ã¨ãã«ä½¿ã†
 		concurrency::task<void> asyncTask;
 
-		std::wstring collectExePath;//‹N“®‚·‚éEXE‚ÌƒpƒX
+		std::wstring collectExePath;//èµ·å‹•ã™ã‚‹EXEã®ãƒ‘ã‚¹
 
 		static std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> utf8_utf16_conv;
 
@@ -63,11 +63,11 @@ namespace TVTComment
 		void sendCurrentChannelIPCMessage(const TVTest::ChannelInfo &ci,const TVTest::ProgramInfo &pi);
 
 	public:
-		static constexpr int WM_USERINTERACTIONREQUEST = WM_APP + 1001;//ƒ_ƒCƒAƒƒOƒ{ƒbƒNƒX‚Ì•\¦‚È‚Çƒ†[ƒU[‚Ö‚ÌƒƒbƒZ[ƒW‚ğ•\¦‚·‚é
-		static constexpr int WM_DISABLEPLUGIN = WM_APP + 1002;//ƒvƒ‰ƒOƒCƒ“‚ğ–³Œø‰»‚·‚éi•ÊƒXƒŒƒbƒh‚©‚ç–³Œø‰»‚·‚é‚Æ‚«‚Ég‚¤j
-		static constexpr int WM_ONCHANNELLISTCHANGE = WM_APP + 1003;//ƒƒ“ƒoŠÖ”OnChannelListChange‚ğŒÄ‚Ôi•ÊƒXƒŒƒbƒh‚©‚ç‘—‚é‚Æ‚«‚Ég‚¤j
-		static constexpr int WM_ONCHANNELSELECTIONCHANGE = WM_APP + 1004;//ƒƒ“ƒoŠÖ”OnChannelSelectionChange‚ğŒÄ‚Ôi•ÊƒXƒŒƒbƒh‚©‚ç‘—‚é‚Æ‚«‚Ég‚¤j
-		static constexpr int WM_SETCHATOPACITY = WM_APP + 1005;//ƒRƒƒ“ƒg“§‰ß“x‚ğİ’è‚·‚é wParam‚É“§‰ß“x‚ğ“n‚·(0~255)
+		static constexpr int WM_USERINTERACTIONREQUEST = WM_APP + 1001;//ãƒ€ã‚¤ã‚¢ãƒ­ã‚°ãƒœãƒƒã‚¯ã‚¹ã®è¡¨ç¤ºãªã©ãƒ¦ãƒ¼ã‚¶ãƒ¼ã¸ã®ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ã‚’è¡¨ç¤ºã™ã‚‹
+		static constexpr int WM_DISABLEPLUGIN = WM_APP + 1002;//ãƒ—ãƒ©ã‚°ã‚¤ãƒ³ã‚’ç„¡åŠ¹åŒ–ã™ã‚‹ï¼ˆåˆ¥ã‚¹ãƒ¬ãƒƒãƒ‰ã‹ã‚‰ç„¡åŠ¹åŒ–ã™ã‚‹ã¨ãã«ä½¿ã†ï¼‰
+		static constexpr int WM_ONCHANNELLISTCHANGE = WM_APP + 1003;//ãƒ¡ãƒ³ãƒé–¢æ•°OnChannelListChangeã‚’å‘¼ã¶ï¼ˆåˆ¥ã‚¹ãƒ¬ãƒƒãƒ‰ã‹ã‚‰é€ã‚‹ã¨ãã«ä½¿ã†ï¼‰
+		static constexpr int WM_ONCHANNELSELECTIONCHANGE = WM_APP + 1004;//ãƒ¡ãƒ³ãƒé–¢æ•°OnChannelSelectionChangeã‚’å‘¼ã¶ï¼ˆåˆ¥ã‚¹ãƒ¬ãƒƒãƒ‰ã‹ã‚‰é€ã‚‹ã¨ãã«ä½¿ã†ï¼‰
+		static constexpr int WM_SETCHATOPACITY = WM_APP + 1005;//ã‚³ãƒ¡ãƒ³ãƒˆé€éåº¦ã‚’è¨­å®šã™ã‚‹ wParamã«é€éåº¦ã‚’æ¸¡ã™(0~255)
 
 		enum class UserInteractionRequestType{ConnectSucceed,ConnectFail,InvalidMessage,ReceiveError,SendError, FetalErrorInTask};
 
@@ -77,7 +77,7 @@ namespace TVTComment
 		INT_PTR DialogProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 		void OnChannelListChange();
 		void OnChannelSelectionChange();
-		void OnForward(std::time_t tot);//TOT‚ÌXVŠÔŠu‚æ‚è×‚©‚¢ŠÔŠu‚ÅŒÄ‚Ô
+		void OnForward(std::time_t tot);//TOTæ™‚åˆ»ã®æ›´æ–°é–“éš”ã‚ˆã‚Šç´°ã‹ã„é–“éš”ã§å‘¼ã¶
 		void OnCommandInvoked(TVTCommentCommand command);
 		~TVTComment() noexcept;
 	};

--- a/NicoJK/TVTComment/win32filebuf.cpp
+++ b/NicoJK/TVTComment/win32filebuf.cpp
@@ -1,4 +1,4 @@
-#include "stdafx.h"
+ï»¿#include "stdafx.h"
 #include "win32filebuf.h"
 #include <cstring>
 #include <algorithm>
@@ -26,8 +26,8 @@ std::streamsize basic_win32filebuf<charT, traits>::xsputn(const typename basic_w
 		std::streamsize charsFree=this->epptr()-this->pptr();
 		if (charsFree<n-ret)
 		{
-			//s‚ÉŽc‚Á‚Ä‚¢‚éƒf[ƒ^‚ð‚·‚×‚Äƒoƒbƒtƒ@‚É‘‚«ž‚Þ‚Æƒoƒbƒtƒ@‚Ì‹ó‚«‚ð’´‚¦‚é‚È‚ç
-			//ƒoƒbƒtƒ@‚Ì‹ó‚«‚Ì•ª‚¾‚¯‘‚«ž‚ñ‚ÅAƒoƒbƒtƒ@‚ðÁ”ï‚·‚é‚½‚ßoverflow‚ðŒÄ‚Ô
+			//sã«æ®‹ã£ã¦ã„ã‚‹ãƒ‡ãƒ¼ã‚¿ã‚’ã™ã¹ã¦ãƒãƒƒãƒ•ã‚¡ã«æ›¸ãè¾¼ã‚€ã¨ãƒãƒƒãƒ•ã‚¡ã®ç©ºãã‚’è¶…ãˆã‚‹ãªã‚‰
+			//ãƒãƒƒãƒ•ã‚¡ã®ç©ºãã®åˆ†ã ã‘æ›¸ãè¾¼ã‚“ã§ã€ãƒãƒƒãƒ•ã‚¡ã‚’æ¶ˆè²»ã™ã‚‹ãŸã‚overflowã‚’å‘¼ã¶
 			traits::copy(this->pptr(), s + ret, (std::size_t)charsFree);
 			this->pbump((int)charsFree);
 			ret += charsFree;
@@ -36,8 +36,8 @@ std::streamsize basic_win32filebuf<charT, traits>::xsputn(const typename basic_w
 		}
 		else
 		{
-			//s‚ÉŽc‚Á‚Ä‚¢‚éƒf[ƒ^‚ð‚·‚×‚Äƒoƒbƒtƒ@‚É‘‚«ž‚ñ‚Å‚à‚Ü‚¾ƒoƒbƒtƒ@‚Ì‘å‚«‚³‚É‚Æ‚Ç‚©‚È‚¢‚È‚ç
-			//Žc‚è‚ð‚·‚×‚Ä‘‚«ž‚Þ
+			//sã«æ®‹ã£ã¦ã„ã‚‹ãƒ‡ãƒ¼ã‚¿ã‚’ã™ã¹ã¦ãƒãƒƒãƒ•ã‚¡ã«æ›¸ãè¾¼ã‚“ã§ã‚‚ã¾ã ãƒãƒƒãƒ•ã‚¡ã®å¤§ãã•ã«ã¨ã©ã‹ãªã„ãªã‚‰
+			//æ®‹ã‚Šã‚’ã™ã¹ã¦æ›¸ãè¾¼ã‚€
 			traits::copy(this->pptr(), s + ret, (std::size_t)(n - ret));
 			this->pbump((int)(n - ret));
 			return n;
@@ -54,8 +54,8 @@ std::streamsize basic_win32filebuf<charT, traits>::xsgetn(typename basic_win32fi
 		std::streamsize charsLeft = this->egptr() - this->gptr();
 		if (ret+charsLeft < n)
 		{
-			//ƒoƒbƒtƒ@‚ð‚·‚×‚Äs‚É‘‚«ž‚ñ‚Å‚à‚Ü‚¾n‚É‚Æ‚Ç‚©‚È‚¢‚È‚ç
-			//¡‚ ‚éƒoƒbƒtƒ@‚ð‚·‚×‚Ä‘‚«ž‚ñ‚ÅAV‚½‚Éƒoƒbƒtƒ@‚Éƒf[ƒ^‚ðæ‚¹‚é‚½‚ßunderflow‚ðŒÄ‚Ô
+			//ãƒãƒƒãƒ•ã‚¡ã‚’ã™ã¹ã¦sã«æ›¸ãè¾¼ã‚“ã§ã‚‚ã¾ã nã«ã¨ã©ã‹ãªã„ãªã‚‰
+			//ä»Šã‚ã‚‹ãƒãƒƒãƒ•ã‚¡ã‚’ã™ã¹ã¦æ›¸ãè¾¼ã‚“ã§ã€æ–°ãŸã«ãƒãƒƒãƒ•ã‚¡ã«ãƒ‡ãƒ¼ã‚¿ã‚’ä¹—ã›ã‚‹ãŸã‚underflowã‚’å‘¼ã¶
 			traits::copy(s+ret, this->gptr(), (std::size_t)charsLeft);
 			this->gbump((int)charsLeft);
 			ret += charsLeft;
@@ -64,8 +64,8 @@ std::streamsize basic_win32filebuf<charT, traits>::xsgetn(typename basic_win32fi
 		}
 		else
 		{
-			//ƒoƒbƒtƒ@‚ð‚·‚×‚Äs‚É‘‚«ž‚Þ‚Æn‚ð’´‚¦‚Ä‚µ‚Ü‚¤‚È‚ç
-			//‘‚«ž‚ß‚é‚¾‚¯‘‚«ž‚Þ
+			//ãƒãƒƒãƒ•ã‚¡ã‚’ã™ã¹ã¦sã«æ›¸ãè¾¼ã‚€ã¨nã‚’è¶…ãˆã¦ã—ã¾ã†ãªã‚‰
+			//æ›¸ãè¾¼ã‚ã‚‹ã ã‘æ›¸ãè¾¼ã‚€
 			traits::copy(s+ret, this->gptr(), (std::size_t)(n - ret));
 			this->gbump((int)(n - ret));
 			return n;


### PR DESCRIPTION
https://github.com/SlashNephy/TVTest-builder で自分用に GitHub Actions 上でビルドしているのですが、CI で動作している英語版 Windows では `Shift-JIS` のソースコードをビルドした際に成果物が文字化けしてしまうようです。(例えばエラーダイアログ)

ソースコードのエンコーディングを `UTF-8 BOM` にすることで、従来どおり Visual Studio でも GitHub Actions でも `UTF-8 BOM` のソースコードをビルドできますので、マージの方検討おねがいします。
