### PR TITLE
dotnet publish でビルドした際に .NET 5.0 ランタイムが含まれてしまうのを修正

### DIFF
--- a/.github/workflows/AutoBuild.yml
+++ b/.github/workflows/AutoBuild.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           New-Item -Path Asset -ItemType Directory
           New-Item -Path Asset/misc -ItemType Directory
-          Copy-Item -Path TVTComment/bin/Release/net5.0-windows/publish/TvtComment.exe -Destination Asset/
+          Copy-Item -Path TVTComment/bin/Release/net6.0-windows/publish/TvtComment.exe -Destination Asset/
           Copy-Item -Path TVTComment/Data/* -Destination Asset/
           Copy-Item -Path CHANGELOG.md -Destination Asset/misc/CHANGELOG.txt
           Copy-Item -Path LICENSE -Destination Asset/misc/LICENSE.txt

--- a/.github/workflows/AutoBuildAndRelease.yml
+++ b/.github/workflows/AutoBuildAndRelease.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           New-Item -Path Asset -ItemType Directory
           New-Item -Path Asset/misc -ItemType Directory
-          Copy-Item -Path TVTComment/bin/Release/net5.0-windows/publish/TvtComment.exe -Destination Asset/
+          Copy-Item -Path TVTComment/bin/Release/net6.0-windows/publish/TvtComment.exe -Destination Asset/
           Copy-Item -Path TVTComment/Data/* -Destination Asset/
           Copy-Item -Path CHANGELOG.md -Destination Asset/misc/CHANGELOG.txt
           Copy-Item -Path LICENSE -Destination Asset/misc/LICENSE.txt

--- a/TVTComment/Properties/PublishProfiles/DebugProfile.pubxml
+++ b/TVTComment/Properties/PublishProfiles/DebugProfile.pubxml
@@ -6,9 +6,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Debug</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Debug\net5.0-windows\publish\</PublishDir>
+    <PublishDir>bin\Debug\net6.0-windows\publish\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>True</PublishSingleFile>

--- a/TVTComment/Properties/PublishProfiles/ReleaseProfile.pubxml
+++ b/TVTComment/Properties/PublishProfiles/ReleaseProfile.pubxml
@@ -6,9 +6,9 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <Configuration>Release</Configuration>
     <Platform>Any CPU</Platform>
-    <PublishDir>bin\Release\net5.0-windows\publish\</PublishDir>
+    <PublishDir>bin\Release\net6.0-windows\publish\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <SelfContained>true</SelfContained>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <PublishSingleFile>True</PublishSingleFile>


### PR DESCRIPTION
.NET 6 対応ありがとうございました! いくつか気付いたところを修正させていただきました

- `TVTComment/Properties/PublishProfiles/ReleaseProfile.pubxml` を使ってシングルバイナリを生成した場合に `<SelfContained>true</SelfContained>` が指定されているため、古い .NET 5 ランタイムが埋め込まれてしまっていたのを修正しました
  - https://learn.microsoft.com/en-us/dotnet/core/deploying/#publish-self-contained
- ついでに出力パスを .NET 6 に合わせました