### PR TITLE
ウィンドウスレッド以外からTVTestのAPIを呼び出さないようにする、など

### DIFF
--- a/TVTComment/Model/IPC/IPCMessage/ChatIPCMessage.cs
+++ b/TVTComment/Model/IPC/IPCMessage/ChatIPCMessage.cs
@@ -17,7 +17,7 @@ namespace TVTComment.Model.IPC.IPCMessage
         public IEnumerable<string> Encode()
         {
             string[] ret = new string[5];
-            ret[0] = Chat.Text;
+            ret[0] = Chat.Text.Replace('\u001E', '〓').Replace('\u001F', '〓');
             switch (Chat.Position)
             {
                 case Chat.PositionType.Normal:

--- a/Viewer/TVTComment/IPC/RawIPCMessage.cpp
+++ b/Viewer/TVTComment/IPC/RawIPCMessage.cpp
@@ -5,10 +5,9 @@ namespace TVTComment
 {
 	std::string RawIPCMessage::ToString() const
 	{
-		std::string ret;
+		std::string ret = this->MessageName;
 		for (const std::string &content : this->Contents)
-			ret += content+" ";
-		ret.pop_back();
-		return this->MessageName + ret;
+			ret += " " + content;
+		return ret;
 	}
 }

--- a/Viewer/TVTComment/TVTComment.cpp
+++ b/Viewer/TVTComment/TVTComment.cpp
@@ -48,6 +48,8 @@ namespace TVTComment
 				if (CreateProcessW(NULL, &(this->collectExePath + L" " + receivePipeName.substr(9) + L" " + sendPipeName.substr(9))[0], NULL, NULL, FALSE, NORMAL_PRIORITY_CLASS, NULL, NULL, &si, &pi) == 0)
 					throw std::system_error(std::system_error(GetLastError(), std::system_category()));
 				pid = pi.dwProcessId;
+				CloseHandle(pi.hProcess);
+				CloseHandle(pi.hThread);
 
 				this->ipcTunnel->Connect();
 			}

--- a/Viewer/TVTComment/TVTComment.h
+++ b/Viewer/TVTComment/TVTComment.h
@@ -53,6 +53,11 @@ namespace TVTComment
 
 		std::wstring collectExePath;//起動するEXEのパス
 
+		int channelSelectSpaceIndex;//WM_CHANNELSELECTをタイムアウトつきで呼び出すときの引数
+		int channelSelectChannelIndex;
+		uint16_t channelSelectServiceId;
+		static constexpr int CHANNELSELECT_TIMEOUT = 5000;//WM_CHANNELSELECTの完了を待つタイムアウト（ミリ秒）
+
 		static std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>, wchar_t> utf8_utf16_conv;
 
 	private:
@@ -69,7 +74,8 @@ namespace TVTComment
 		static constexpr int WM_DISABLEPLUGIN = WM_APP + 1002;//プラグインを無効化する（別スレッドから無効化するときに使う）
 		static constexpr int WM_ONCHANNELLISTCHANGE = WM_APP + 1003;//メンバ関数OnChannelListChangeを呼ぶ（別スレッドから送るときに使う）
 		static constexpr int WM_ONCHANNELSELECTIONCHANGE = WM_APP + 1004;//メンバ関数OnChannelSelectionChangeを呼ぶ（別スレッドから送るときに使う）
-		static constexpr int WM_SETCHATOPACITY = WM_APP + 1005;//コメント透過度を設定する wParamに透過度を渡す(0~255)
+		static constexpr int WM_SETCHATOPACITY = WM_APP + 1005;//コメント透過度を設定する wParamに透過度(0~255)、lParamに表示状態（非0で非表示）を渡す
+		static constexpr int WM_CHANNELSELECT = WM_APP + 1006;//チャンネル変更する
 
 		enum class UserInteractionRequestType{ConnectSucceed,ConnectFail,InvalidMessage,ReceiveError,SendError, FetalErrorInTask};
 

--- a/Viewer/Viewer.cpp
+++ b/Viewer/Viewer.cpp
@@ -541,6 +541,8 @@ LRESULT CViewer::ForceWindowProcMain(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM
 			commentWindow_.Destroy();
 		}
 		commentWindow_.SetOpacity(newOpacity);
+		bool hideState = lParam != 0;
+		m_pApp->SetPluginCommandState(static_cast<int>(TVTComment::Command::HideComment), hideState ? TVTest::COMMAND_ICON_STATE_CHECKED : 0);
 		break;
 	}
 #pragma endregion


### PR DESCRIPTION
4点いずれもsilane氏版に由来するバグですが、更新を停止しているようで動作検証ができないのでこちらに送ります。
(コミット自体はsilane氏版にも適用可能なはず)
3点が主要なもので acb13b4eec957e2a7a83ad453617d10afce36f3a はとくに重要ではないです。
よろしくお願いします。
